### PR TITLE
Add MySQL database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ PORT=3000
 
 <details>   
 <summary><strong>MySQL</strong></summary>
+
+```bash
 DB_DIALECT=mysql
 DB_HOST=localhost
 DB_PORT=3306
@@ -57,6 +59,27 @@ DB_DATABASE=mydb
 DB_USER=myuser
 DB_PASSWORD=mypassword
 PORT=3000
+```
+
+**MySQL Setup Notes:**
+- Ensure your MySQL server is running and accessible
+- The user must have `SELECT`, `INSERT`, `UPDATE`, `DELETE` privileges on the database
+- For schema introspection, the user needs access to `information_schema` tables
+- Both local and remote MySQL servers are supported
+- SSL connections are supported but not required for local development
+
+**Quick MySQL Setup:**
+```bash
+# Copy the example configuration
+cp env.mysql.example .env
+
+# Edit with your MySQL credentials
+nano .env
+
+# Start the application
+npm run dev
+```
+
 </details> 
 
 <details> 

--- a/app/types/query.ts
+++ b/app/types/query.ts
@@ -360,5 +360,5 @@ export interface Table {
   columns: Column[];
   primary_keys: string[];
   foreign_keys: ForeignKey[];
-  values?: string[];
+  values: Record<string, unknown>[];
 }

--- a/env.mysql.example
+++ b/env.mysql.example
@@ -1,0 +1,25 @@
+# MySQL Configuration Example
+# Copy this to .env and update with your MySQL database credentials
+
+# Database Configuration
+DB_DIALECT=mysql
+DB_HOST=localhost
+DB_PORT=3306
+DB_DATABASE=your_database_name
+DB_USER=your_mysql_user
+DB_PASSWORD=your_mysql_password
+
+# Server Configuration
+PORT=3000
+
+# Example MySQL connection strings:
+# - Local MySQL: localhost:3306
+# - MySQL with custom port: localhost:3307
+# - Remote MySQL: your-mysql-server.com:3306
+# - Docker MySQL: mysql-container:3306
+
+# Notes:
+# - Make sure your MySQL server is running and accessible
+# - The user must have SELECT, INSERT, UPDATE, DELETE privileges on the database
+# - For schema introspection, the user needs access to information_schema tables
+# - SSL connections are supported but not required for local development


### PR DESCRIPTION
# �� Add MySQL Database Support

This PR adds comprehensive MySQL support to SculptQL, enabling users to connect to MySQL databases through the CLI tool using environment variables.

## ✨ Features Added

- **Multi-Database Support**: Database abstraction layer supporting PostgreSQL and MySQL
- **MySQL Schema Introspection**: Optimized queries for MySQL's `information_schema`
- **Connection Pooling**: Efficient `mysql2` connection management
- **Parameter Handling**: Proper MySQL `?` vs PostgreSQL `$1` syntax support
- **Error Handling**: MySQL-specific error messages and troubleshooting

## �� Technical Changes

### Core Architecture
- Created `DatabaseAdapter` interface for database abstraction
- Implemented `PostgresAdapter` and `MySqlAdapter` classes
- Added `SqlQueries` class with database-specific query generation
- Updated GraphQL resolvers to use database abstraction layer

### Type Safety Improvements
- Updated `Table` interface to use `Record<string, unknown>[]` for values

### MySQL-Specific Implementation
- MySQL connection pooling with `mysql2/promise`
- Database-specific SQL queries for schema introspection
- MySQL EXPLAIN query support (timing disabled for compatibility)
- Proper handling of MySQL parameter placeholders

## 📚 Documentation

- Enhanced README with detailed MySQL setup instructions
- Added `env.mysql.example` configuration template
- Included troubleshooting tips and requirements


## �� Usage

Users can now connect to MySQL by setting environment variables:

```bash
# Copy example configuration
cp env.mysql.example .env

# Edit with MySQL credentials
DB_DIALECT=mysql
DB_HOST=localhost
DB_PORT=3306
DB_DATABASE=your_database
DB_USER=your_user
DB_PASSWORD=your_password

# Run CLI tool
npx sculptql
```

## �� What Works

- SQL query execution with full MySQL support
